### PR TITLE
2.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 2.2.3
 
 * [Fixed] - #141 - thread leak due to null pointer
+* [Fixed] - #136 - added a way to block data being stored for every ack
 
 ## Version 2.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Version 2.2.3
+
+* [Fixed] - #141 - thread leak due to null pointer
+
 ## Version 2.2.2
 
 * [Changed] - small fixes to automate the build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A [Java](http://java.com) client for the [NATS streaming platform](https://nats.
 
 ## A Note on Versions
 
-This is version 2.2.2 of the Java NATS streaming library. This version is a port to version 2.x of the Java NATS library and contains breaking changes due to the way the underlying library handles exceptions, especially timeouts. For 2.1.6 we are renaming this repo to stan.java.
+This is version 2.2.3 of the Java NATS streaming library. This version is a port to version 2.x of the Java NATS library and contains breaking changes due to the way the underlying library handles exceptions, especially timeouts. For 2.1.6 we are renaming this repo to stan.java.
 
 As of 2.1.6 the NATS server is undergoing a rename, as are the NATS repositories.
 
@@ -38,7 +38,7 @@ The nats streaming client requires two jar files to run, the java nats library a
 
 You can download the latest NATS client jar at [https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.6.0/jnats-2.6.0.jar](https://search.maven.org/remotecontent?filepath=io/nats/jnats/2.6.0/jnats-2.6.0.jar).
 
-You can download the latest java nats streaming jar at [https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.2.2/java-nats-streaming-2.2.2.jar](https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.2.2/java-nats-streaming-2.2.2.jar).
+You can download the latest java nats streaming jar at [https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.2.3/java-nats-streaming-2.2.3.jar](https://search.maven.org/remotecontent?filepath=io/nats/java-nats-streaming/2.2.3/java-nats-streaming-2.2.3.jar).
 
 ### Using Gradle
 
@@ -46,7 +46,7 @@ The NATS client is available in the Maven central repository, and can be importe
 
 ```groovy
 dependencies {
-    implementation 'io.nats:java-nats-streaming:2.2.2'
+    implementation 'io.nats:java-nats-streaming:2.2.3'
 }
 ```
 
@@ -72,7 +72,7 @@ The NATS client is available on the Maven central repository, and can be importe
 <dependency>
     <groupId>io.nats</groupId>
     <artifactId>java-nats-streaming</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ plugins {
 // Update version here, repeated check-ins not into master will have snapshot on them
 def versionMajor = 2
 def versionMinor = 2
-def versionPatch = 2
+def versionPatch = 3
 def versionModifier = ""
-def jarVersion = "2.2.2"
+def jarVersion = "2.2.3"
 def branch = System.getenv("TRAVIS_BRANCH");
 def tag = System.getenv("TRAVIS_TAG");
 def useSigning = "master".equals(branch) || (!"".equals(tag) && tag.equals(branch)) // tag will be the branch on a tag event for travis

--- a/src/main/java/io/nats/streaming/AckHandler.java
+++ b/src/main/java/io/nats/streaming/AckHandler.java
@@ -24,7 +24,6 @@ public interface AckHandler {
      * encountered.
      * 
      * onAck with a message is now called, with the default behavior of calling this version.
-     * Not deprecated yet to avoid multiple warnings, will deprecate in the future.
      * 
      * @param nuid the message NUID
      * @param ex   any exception that was encountered
@@ -47,5 +46,18 @@ public interface AckHandler {
      */
     default void onAck(String nuid, String subject, byte[] data, Exception ex) {
         this.onAck(nuid, ex);
+    }
+
+    /**
+     * Tells the connection if it should hold the data from a publish and send it to the ack handler.
+     * 
+     * Added as a default in 2.2.3 to allow apps to stop data retention in the connection. The default
+     * version returns true. Override and return false to always receive null in the onAck and prevent
+     * message accumulation when large acks in flight are used.
+     * 
+     * @return true to include data with the onAck callback, false to include null
+     */
+    default boolean includeDataWithAck() {
+        return true;
     }
 }

--- a/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
+++ b/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
@@ -466,7 +466,7 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
         String ackSubject;
         Duration ackTimeout = opts.getAckTimeout();
         BlockingQueue<PubAck> pac;
-        final AckClosure a= new AckClosure(ah, subject, (ah != null) ? data : null, ch);
+        final AckClosure a= new AckClosure(ah, subject, (ah != null && ah.includeDataWithAck()) ? data : null, ch);
         final PubMsg pe;
         String guid;
         byte[] bytes;


### PR DESCRIPTION

## Version 2.2.3

* [Fixed] - #141 - thread leak due to null pointer
* [Fixed] - #136 - added a way to block data being stored for every ack