### PR TITLE
NPE fix for closing with pending AckClosure(s) on Android

### DIFF
--- a/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
+++ b/src/main/java/io/nats/streaming/StreamingConnectionImpl.java
@@ -354,7 +354,8 @@ class StreamingConnectionImpl implements StreamingConnection, io.nats.client.Mes
                     for (AckClosure ac : this.pubAckMap.values()) {
                         ac.ackTask.cancel();
 
-                        if (!ac.ch.isEmpty()) {
+                        // Note: Providing an Ack Handler when publishing to STAN (on Android) can result in NPEs during some closing scenarios
+                        if (ac.ch != null && !ac.ch.isEmpty()) {
                             ac.ch.take();
                         }
                     }


### PR DESCRIPTION
Calling publish on an instance of StreamingConnection with an AckHandler can result in NPEs if the connection is closed before ACKs have been sent. The result should be an "java.lang.IllegalStateException: stan: connection closed"; however, the result in an NPE.

Note: I am working on Android using Kotlin.

```
  val opts: Options? = Options.Builder().natsUrl("nats://10.0.2.2:4222").clientId("android-client").clusterId("test-cluster").build()
        val cf = StreamingConnectionFactory(opts)
        val sc = cf.createConnection()

        // Note: Proving an AckHandler can result in NPEs when closing the StreamingConnection
        sc.publish("foo", "Hello World".toByteArray(), AckHandler { nuid, ex ->
            Log.i("Test", "Ack for nuid $nuid and ex $ex")
        })

        uiScope.launch {
            val r = Random()
            var count = 10
            while (count-- > 0) {
                var message = "Value: ${r.nextInt(10000)}"
                // Note: Proving an AckHandler can result in NPEs when closing the StreamingConnection
                sc.publish("foo", "Message $count: ${message}".toByteArray(), AckHandler { nuid, ex ->
                    Log.i("Test", "Ack for nuid $nuid and ex $ex")
                })

                delay(100)
                // Introduce an early close to generate an NPE rather than an IllegalStateException
                sc.close()
            }
            sc.close()
        }
```